### PR TITLE
Replace `failure` with `thiserror` and `anyhow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/chinedufn/psd"
 edition = "2018"
 
 [dependencies]
-failure = "0.1.5"
+thiserror = "1.0"
+anyhow = "1.0"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2018"
 
 [dependencies]
 thiserror = "1.0"
+
+[dev-dependencies]
 anyhow = "1.0"
 
 [workspace]

--- a/src/blend.rs
+++ b/src/blend.rs
@@ -1,5 +1,3 @@
-use std::cmp::min;
-
 use crate::sections::layer_and_mask_information_section::layer::BlendMode;
 
 // Multiplies the pixel's current alpha by the passed in `opacity`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use failure::Error;
+use anyhow::Result;
 
 use crate::psd_channel::IntoRgba;
 pub use crate::psd_channel::{PsdChannelCompression, PsdChannelKind};
@@ -57,7 +57,7 @@ impl Psd {
     ///
     /// let psd = Psd::from_bytes(psd_bytes);
     /// ```
-    pub fn from_bytes(bytes: &[u8]) -> Result<Psd, Error> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Psd> {
         let major_sections = MajorSections::from_bytes(bytes)?;
 
         let file_header_section = FileHeaderSection::from_bytes(major_sections.file_header)?;
@@ -122,7 +122,7 @@ impl Psd {
     }
 
     /// Get a layer by name
-    pub fn layer_by_name(&self, name: &str) -> Result<&PsdLayer, Error> {
+    pub fn layer_by_name(&self, name: &str) -> Result<&PsdLayer> {
         let item = self
             .layer_and_mask_information_section
             .layers
@@ -134,7 +134,7 @@ impl Psd {
     /// Get a layer by index.
     ///
     /// index 0 is the bottom layer, index 1 is the layer above that, etc
-    pub fn layer_by_idx(&self, idx: usize) -> Result<&PsdLayer, Error> {
+    pub fn layer_by_idx(&self, idx: usize) -> Result<&PsdLayer> {
         let item = self
             .layer_and_mask_information_section
             .layers
@@ -185,7 +185,7 @@ impl Psd {
     pub fn flatten_layers_rgba(
         &self,
         filter: &dyn Fn((usize, &PsdLayer)) -> bool,
-    ) -> Result<Vec<u8>, Error> {
+    ) -> Result<Vec<u8>> {
         // When you create a PSD but don't create any new layers the bottom layer might not
         // show up in the layer and mask information section, so we won't see any layers.
         //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod sections;
 ///
 /// This list is intended to grow over time and it is not recommended to exhaustively match against it.
 #[derive(PartialEq, Debug, Error)]
+#[non_exhaustive]
 pub enum PsdError {
     /// Failed to parse PSD header
     #[error("Failed to parse PSD header: '{0}'.")]

--- a/src/psd_channel.rs
+++ b/src/psd_channel.rs
@@ -152,13 +152,13 @@ pub trait IntoRgba {
         let offset = channel_kind.rgba_offset().unwrap();
 
         while cursor.position() != cursor.get_ref().len() as u64 {
-            let header = cursor.read_i8().unwrap() as i16;
+            let header = cursor.read_i8() as i16;
 
             if header == -128 {
                 continue;
             } else if header >= 0 {
                 let bytes_to_read = 1 + header;
-                for byte in cursor.read(bytes_to_read as u32).unwrap() {
+                for byte in cursor.read(bytes_to_read as u32) {
                     let rgba_idx = self.rgba_idx(idx);
                     rgba[rgba_idx * 4 + offset] = *byte;
 
@@ -166,7 +166,7 @@ pub trait IntoRgba {
                 }
             } else {
                 let repeat = 1 - header;
-                let byte = cursor.read_1().unwrap()[0];
+                let byte = cursor.read_1()[0];
                 for _ in 0..repeat as usize {
                     let rgba_idx = self.rgba_idx(idx);
                     rgba[rgba_idx * 4 + offset] = byte;
@@ -185,18 +185,18 @@ fn rle_decompress(bytes: &[u8]) -> Vec<u8> {
     let mut decompressed = vec![];
 
     while cursor.position() != cursor.get_ref().len() as u64 {
-        let header = cursor.read_i8().unwrap() as i16;
+        let header = cursor.read_i8() as i16;
 
         if header == -128 {
             continue;
         } else if header >= 0 {
             let bytes_to_read = 1 + header;
-            for byte in cursor.read(bytes_to_read as u32).unwrap() {
+            for byte in cursor.read(bytes_to_read as u32) {
                 decompressed.push(*byte);
             }
         } else {
             let repeat = 1 - header;
-            let byte = cursor.read_1().unwrap()[0];
+            let byte = cursor.read_1()[0];
             for _ in 0..repeat as usize {
                 decompressed.push(byte);
             }

--- a/src/sections/file_header_section.rs
+++ b/src/sections/file_header_section.rs
@@ -77,41 +77,41 @@ impl FileHeaderSection {
         }
 
         // First four bytes must be '8BPS'
-        let signature = cursor.read_4()?;
+        let signature = cursor.read_4();
         if signature != EXPECTED_PSD_SIGNATURE {
             return Err(FileHeaderSectionError::InvalidSignature {}.into());
         }
 
         // The next 2 bytes represent the version
-        let version = cursor.read_2()?;
+        let version = cursor.read_2();
         if version != EXPECTED_VERSION {
             return Err(FileHeaderSectionError::InvalidVersion {}.into());
         }
 
         // The next 6 bytes are reserved and should always be 0
-        let reserved = cursor.read_6()?;
+        let reserved = cursor.read_6();
         if reserved != EXPECTED_RESERVED {
             return Err(FileHeaderSectionError::InvalidReserved {}.into());
         }
 
         // The next 2 bytes represent the channel count
-        let channel = cursor.read_u16()?;
+        let channel = cursor.read_u16();
         let channel_count = ChannelCount::new(channel as u8)?;
 
         // 4 bytes for the height
-        let height = cursor.read_u32()?;
+        let height = cursor.read_u32();
         let height = PsdHeight::new(height)?;
 
         // 4 bytes for the width
-        let width = cursor.read_u32()?;
+        let width = cursor.read_u32();
         let width = PsdWidth::new(width)?;
 
         // 2 bytes for depth
-        let depth = cursor.read_2()?;
+        let depth = cursor.read_2();
         let depth = PsdDepth::new(depth[1])?;
 
         // 2 bytes for color mode
-        let color_mode = cursor.read_2()?;
+        let color_mode = cursor.read_2();
         let color_mode = ColorMode::new(color_mode[1])?;
 
         let file_header_section = FileHeaderSection {

--- a/src/sections/image_data_section.rs
+++ b/src/sections/image_data_section.rs
@@ -2,7 +2,7 @@ use crate::psd_channel::PsdChannelCompression;
 use crate::sections::file_header_section::PsdDepthError;
 use crate::sections::PsdCursor;
 use crate::PsdDepth;
-use failure::Error;
+use anyhow::Result;
 
 /// The ImageDataSection comes from the final section in the PSD that contains the pixel data
 /// of the final PSD image (the one that comes from combining all of the layers).
@@ -40,7 +40,7 @@ impl ImageDataSection {
         depth: PsdDepth,
         psd_height: u32,
         channel_count: u8,
-    ) -> Result<ImageDataSection, Error> {
+    ) -> Result<ImageDataSection> {
         let mut cursor = PsdCursor::new(bytes);
         let channel_count = channel_count as usize;
 

--- a/src/sections/image_data_section.rs
+++ b/src/sections/image_data_section.rs
@@ -53,7 +53,6 @@ impl ImageDataSection {
         psd_height: u32,
         channel_count: u8,
     ) -> Result<ImageDataSection, ImageDataSectionError> {
-        // PsdChannelError, PsdDepthError
         let mut cursor = PsdCursor::new(bytes);
         let channel_count = channel_count as usize;
 

--- a/src/sections/image_data_section.rs
+++ b/src/sections/image_data_section.rs
@@ -44,7 +44,7 @@ impl ImageDataSection {
         let mut cursor = PsdCursor::new(bytes);
         let channel_count = channel_count as usize;
 
-        let compression = cursor.read_u16()?;
+        let compression = cursor.read_u16();
         let compression = PsdChannelCompression::new(compression)?;
 
         let (red, green, blue, alpha) = match compression {
@@ -117,24 +117,24 @@ impl ImageDataSection {
                 let mut alpha_byte_count = if channel_count == 4 { Some(0) } else { None };
 
                 for _ in 0..psd_height {
-                    red_byte_count += cursor.read_u16()? as usize;
+                    red_byte_count += cursor.read_u16() as usize;
                 }
 
                 if let Some(ref mut green_byte_count) = green_byte_count {
                     for _ in 0..psd_height {
-                        *green_byte_count += cursor.read_u16()? as usize;
+                        *green_byte_count += cursor.read_u16() as usize;
                     }
                 }
 
                 if let Some(ref mut blue_byte_count) = blue_byte_count {
                     for _ in 0..psd_height {
-                        *blue_byte_count += cursor.read_u16()? as usize;
+                        *blue_byte_count += cursor.read_u16() as usize;
                     }
                 }
 
                 if let Some(ref mut alpha_byte_count) = alpha_byte_count {
                     for _ in 0..psd_height {
-                        *alpha_byte_count += cursor.read_u16()? as usize;
+                        *alpha_byte_count += cursor.read_u16() as usize;
                     }
                 }
 

--- a/src/sections/image_resources_section.rs
+++ b/src/sections/image_resources_section.rs
@@ -41,7 +41,7 @@ impl ImageResourcesSection {
 
         let mut resources = vec![];
 
-        let length = cursor.read_u32()? as u64;
+        let length = cursor.read_u32() as u64;
 
         while cursor.position() < length {
             let block = ImageResourcesSection::read_resource_block(&mut cursor)?;
@@ -74,15 +74,15 @@ impl ImageResourcesSection {
     /// +----------+--------------------------------------------------------------------------------------------------------------------+
     fn read_resource_block(cursor: &mut PsdCursor) -> Result<ImageResourcesBlock> {
         // First four bytes must be '8BIM'
-        let signature = cursor.read_4()?;
+        let signature = cursor.read_4();
         if signature != EXPECTED_RESOURCE_BLOCK_SIGNATURE {
             return Err(ImageResourcesSectionError::InvalidSignature {}.into());
         }
 
-        let resource_id = cursor.read_i16()?;
-        let name = cursor.read_pascal_string()?;
+        let resource_id = cursor.read_i16();
+        let name = cursor.read_pascal_string();
 
-        let data_len = cursor.read_u32()?;
+        let data_len = cursor.read_u32();
         let pos = cursor.position() as usize;
         // Note: data length is padded to even.
         let data_len = data_len + data_len % 2;
@@ -90,7 +90,7 @@ impl ImageResourcesSection {
             start: pos,
             end: pos + data_len as usize,
         };
-        cursor.read(data_len)?;
+        cursor.read(data_len);
 
         Ok(ImageResourcesBlock {
             resource_id,
@@ -112,21 +112,21 @@ impl ImageResourcesSection {
     fn read_slice_block(bytes: &[u8]) -> Result<SlicesImageResource> {
         let mut cursor = PsdCursor::new(bytes);
 
-        let version = cursor.read_i32()?;
+        let version = cursor.read_i32();
         if version != 6 {
             unimplemented!(
                 "Only the Adobe Photoshop 6.0 slices resource format is currently supported"
             );
         }
 
-        let _top = cursor.read_i32()?;
-        let _left = cursor.read_i32()?;
-        let _bottom = cursor.read_i32()?;
-        let _right = cursor.read_i32()?;
+        let _top = cursor.read_i32();
+        let _left = cursor.read_i32();
+        let _bottom = cursor.read_i32();
+        let _right = cursor.read_i32();
 
-        let group_of_slices_name = cursor.read_unicode_string_padding(1)?;
+        let group_of_slices_name = cursor.read_unicode_string_padding(1);
 
-        let number_of_slices = cursor.read_u32()?;
+        let number_of_slices = cursor.read_u32();
 
         let mut descriptors = Vec::new();
 
@@ -173,44 +173,44 @@ impl ImageResourcesSection {
     /// | Variable                                             | Descriptor (see See Descriptor structure)     |
     /// +------------------------------------------------------+-----------------------------------------------+
     fn read_slice_body(cursor: &mut PsdCursor) -> Result<Option<DescriptorStructure>> {
-        let _slice_id = cursor.read_i32()?;
-        let _group_id = cursor.read_i32()?;
-        let origin = cursor.read_i32()?;
+        let _slice_id = cursor.read_i32();
+        let _group_id = cursor.read_i32();
+        let origin = cursor.read_i32();
 
         // if origin = 1, Associated Layer ID is present
         if origin == 1 {
-            cursor.read_i32()?;
+            cursor.read_i32();
         }
 
-        let _name = cursor.read_unicode_string_padding(1)?;
+        let _name = cursor.read_unicode_string_padding(1);
 
-        let _type = cursor.read_i32()?;
+        let _type = cursor.read_i32();
 
-        let _top = cursor.read_i32()?;
-        let _left = cursor.read_i32()?;
-        let _bottom = cursor.read_i32()?;
-        let _right = cursor.read_i32()?;
+        let _top = cursor.read_i32();
+        let _left = cursor.read_i32();
+        let _bottom = cursor.read_i32();
+        let _right = cursor.read_i32();
 
-        let _url = cursor.read_unicode_string_padding(1)?;
+        let _url = cursor.read_unicode_string_padding(1);
 
-        let _target = cursor.read_unicode_string_padding(1)?;
+        let _target = cursor.read_unicode_string_padding(1);
 
-        let _message = cursor.read_unicode_string_padding(1)?;
+        let _message = cursor.read_unicode_string_padding(1);
 
-        let _alt_tag = cursor.read_unicode_string_padding(1)?;
+        let _alt_tag = cursor.read_unicode_string_padding(1);
 
-        let _cell_text_html = cursor.read_1()?;
-        let _cell_text = cursor.read_unicode_string_padding(1)?;
+        let _cell_text_html = cursor.read_1();
+        let _cell_text = cursor.read_unicode_string_padding(1);
 
-        let _horizontal_alignment = cursor.read_i32()?;
-        let _vertical_alignment = cursor.read_i32()?;
-        let _argb_color = cursor.read_i32()?;
+        let _horizontal_alignment = cursor.read_i32();
+        let _vertical_alignment = cursor.read_i32();
+        let _argb_color = cursor.read_i32();
 
         let pos = cursor.position();
-        let descriptor_version = cursor.peek_u32()?;
+        let descriptor_version = cursor.peek_u32();
 
         Ok(if descriptor_version == EXPECTED_DESCRIPTOR_VERSION {
-            cursor.read_4()?;
+            cursor.read_4();
 
             let descriptor = DescriptorStructure::read_descriptor_structure(cursor)?;
             if descriptor.class_id.as_slice() == [0, 0, 0, 0] {
@@ -500,7 +500,7 @@ pub enum ImageResourcesDescriptorError {
 
 impl DescriptorStructure {
     fn read_descriptor_structure(cursor: &mut PsdCursor) -> Result<DescriptorStructure> {
-        let name = cursor.read_unicode_string_padding(1)?;
+        let name = cursor.read_unicode_string_padding(1);
         let class_id = DescriptorStructure::read_key_length(cursor)?.to_vec();
         let fields = DescriptorStructure::read_fields(cursor, false)?;
 
@@ -515,7 +515,7 @@ impl DescriptorStructure {
         cursor: &mut PsdCursor,
         sub_list: bool,
     ) -> Result<HashMap<String, DescriptorField>> {
-        let count = cursor.read_u32()?;
+        let count = cursor.read_u32();
         let mut m = HashMap::with_capacity(count as usize);
 
         for n in 0..count {
@@ -529,7 +529,7 @@ impl DescriptorStructure {
     }
 
     fn read_list(cursor: &mut PsdCursor, sub_list: bool) -> Result<Vec<DescriptorField>> {
-        let count = cursor.read_u32()?;
+        let count = cursor.read_u32();
         let mut vec = Vec::with_capacity(count as usize);
 
         for n in 0..count {
@@ -542,7 +542,7 @@ impl DescriptorStructure {
 
     fn read_descriptor_field(cursor: &mut PsdCursor) -> Result<DescriptorField> {
         let mut os_type = [0; 4];
-        os_type.copy_from_slice(cursor.read_4()?);
+        os_type.copy_from_slice(cursor.read_4());
 
         let r: DescriptorField = match &os_type {
             OS_TYPE_REFERENCE => {
@@ -554,17 +554,17 @@ impl DescriptorStructure {
             OS_TYPE_LIST => {
                 DescriptorField::List(DescriptorStructure::read_list_structure(cursor)?)
             }
-            OS_TYPE_DOUBLE => DescriptorField::Double(cursor.read_f64()?),
+            OS_TYPE_DOUBLE => DescriptorField::Double(cursor.read_f64()),
             OS_TYPE_UNIT_FLOAT => {
                 DescriptorField::UnitFloat(DescriptorStructure::read_unit_float(cursor)?)
             }
-            OS_TYPE_TEXT => DescriptorField::String(cursor.read_unicode_string_padding(1)?),
+            OS_TYPE_TEXT => DescriptorField::String(cursor.read_unicode_string_padding(1)),
             OS_TYPE_ENUMERATED => DescriptorField::EnumeratedDescriptor(
                 DescriptorStructure::read_enumerated_descriptor(cursor)?,
             ),
-            OS_TYPE_LARGE_INTEGER => DescriptorField::LargeInteger(cursor.read_i64()?),
-            OS_TYPE_INTEGER => DescriptorField::Integer(cursor.read_i32()?),
-            OS_TYPE_BOOL => DescriptorField::Boolean(cursor.read_u8()? > 0),
+            OS_TYPE_LARGE_INTEGER => DescriptorField::LargeInteger(cursor.read_i64()),
+            OS_TYPE_INTEGER => DescriptorField::Integer(cursor.read_i32()),
+            OS_TYPE_BOOL => DescriptorField::Boolean(cursor.read_u8() > 0),
             OS_TYPE_GLOBAL_OBJECT => {
                 DescriptorField::Descriptor(DescriptorStructure::read_descriptor_structure(cursor)?)
             }
@@ -602,14 +602,14 @@ impl DescriptorStructure {
     /// | Variable                                             | Item type: see the tables below for each possible Reference type |
     /// +------------------------------------------------------+------------------------------------------------------------------+
     fn read_reference_structure(cursor: &mut PsdCursor) -> Result<Vec<DescriptorField>> {
-        let count = cursor.read_u32()?;
+        let count = cursor.read_u32();
         let mut vec = Vec::with_capacity(count as usize);
 
         for n in 0..count {
             DescriptorStructure::read_key_length(cursor)?;
 
             let mut os_type = [0; 4];
-            os_type.copy_from_slice(cursor.read_4()?);
+            os_type.copy_from_slice(cursor.read_4());
             vec.push(match &os_type {
                 OS_TYPE_PROPERTY => {
                     DescriptorField::Property(DescriptorStructure::read_property_structure(cursor)?)
@@ -623,8 +623,8 @@ impl DescriptorStructure {
                 OS_TYPE_OFFSET => {
                     DescriptorField::Offset(DescriptorStructure::read_offset_structure(cursor)?)
                 }
-                OS_TYPE_IDENTIFIER => DescriptorField::Identifier(cursor.read_i32()?),
-                OS_TYPE_INDEX => DescriptorField::Index(cursor.read_i32()?),
+                OS_TYPE_IDENTIFIER => DescriptorField::Identifier(cursor.read_i32()),
+                OS_TYPE_INDEX => DescriptorField::Index(cursor.read_i32()),
                 OS_TYPE_NAME => DescriptorField::Name(DescriptorStructure::read_name(cursor)?),
                 _ => return Err(ImageResourcesDescriptorError::InvalidTypeOS {}.into()),
             });
@@ -634,7 +634,7 @@ impl DescriptorStructure {
     }
 
     fn read_property_structure(cursor: &mut PsdCursor) -> Result<PropertyStructure> {
-        let name = cursor.read_unicode_string()?;
+        let name = cursor.read_unicode_string();
         let class_id = DescriptorStructure::read_key_length(cursor)?.to_vec();
         let key_id = DescriptorStructure::read_key_length(cursor)?.to_vec();
 
@@ -647,28 +647,28 @@ impl DescriptorStructure {
 
     fn read_unit_float(cursor: &mut PsdCursor) -> Result<UnitFloatStructure> {
         let mut unit_float = [0; 4];
-        unit_float.copy_from_slice(cursor.read_4()?);
+        unit_float.copy_from_slice(cursor.read_4());
 
         Ok(match &unit_float {
-            UNIT_FLOAT_ANGLE => UnitFloatStructure::Angle(cursor.read_f64()?),
-            UNIT_FLOAT_DENSITY => UnitFloatStructure::Density(cursor.read_f64()?),
-            UNIT_FLOAT_DISTANCE => UnitFloatStructure::Distance(cursor.read_f64()?),
+            UNIT_FLOAT_ANGLE => UnitFloatStructure::Angle(cursor.read_f64()),
+            UNIT_FLOAT_DENSITY => UnitFloatStructure::Density(cursor.read_f64()),
+            UNIT_FLOAT_DISTANCE => UnitFloatStructure::Distance(cursor.read_f64()),
             UNIT_FLOAT_NONE => UnitFloatStructure::None,
-            UNIT_FLOAT_PERCENT => UnitFloatStructure::Percent(cursor.read_f64()?),
-            UNIT_FLOAT_PIXELS => UnitFloatStructure::Pixels(cursor.read_f64()?),
+            UNIT_FLOAT_PERCENT => UnitFloatStructure::Percent(cursor.read_f64()),
+            UNIT_FLOAT_PIXELS => UnitFloatStructure::Pixels(cursor.read_f64()),
             _ => return Err(ImageResourcesDescriptorError::InvalidUnitName {}.into()),
         })
     }
 
     fn read_class_structure(cursor: &mut PsdCursor) -> Result<ClassStructure> {
-        let name = cursor.read_unicode_string()?;
+        let name = cursor.read_unicode_string();
         let class_id = DescriptorStructure::read_key_length(cursor)?.to_vec();
 
         Ok(ClassStructure { name, class_id })
     }
 
     fn read_enumerated_reference(cursor: &mut PsdCursor) -> Result<EnumeratedReference> {
-        let name = cursor.read_unicode_string()?;
+        let name = cursor.read_unicode_string();
         let class_id = DescriptorStructure::read_key_length(cursor)?.to_vec();
         let key_id = DescriptorStructure::read_key_length(cursor)?.to_vec();
         let enum_field = DescriptorStructure::read_key_length(cursor)?.to_vec();
@@ -682,9 +682,9 @@ impl DescriptorStructure {
     }
 
     fn read_offset_structure(cursor: &mut PsdCursor) -> Result<OffsetStructure> {
-        let name = cursor.read_unicode_string()?;
+        let name = cursor.read_unicode_string();
         let class_id = DescriptorStructure::read_key_length(cursor)?.to_vec();
-        let offset = cursor.read_u32()?;
+        let offset = cursor.read_u32();
 
         Ok(OffsetStructure {
             name,
@@ -694,8 +694,8 @@ impl DescriptorStructure {
     }
 
     fn read_alias_structure(cursor: &mut PsdCursor) -> Result<AliasStructure> {
-        let length = cursor.read_u32()?;
-        let data = cursor.read(length)?.to_vec();
+        let length = cursor.read_u32();
+        let data = cursor.read(length).to_vec();
 
         Ok(AliasStructure { data })
     }
@@ -715,15 +715,15 @@ impl DescriptorStructure {
     }
 
     fn read_raw_data(cursor: &mut PsdCursor) -> Result<Vec<u8>> {
-        let length = cursor.read_u32()?;
-        Ok(cursor.read(length)?.to_vec())
+        let length = cursor.read_u32();
+        Ok(cursor.read(length).to_vec())
     }
 
     // Note: this structure is not documented
     fn read_name(cursor: &mut PsdCursor) -> Result<NameStructure> {
-        let name = cursor.read_unicode_string()?;
+        let name = cursor.read_unicode_string();
         let class_id = DescriptorStructure::read_key_length(cursor)?.to_vec();
-        let value = cursor.read_unicode_string()?;
+        let value = cursor.read_unicode_string();
 
         Ok(NameStructure {
             name,
@@ -733,10 +733,10 @@ impl DescriptorStructure {
     }
 
     fn read_key_length<'a>(cursor: &'a mut PsdCursor) -> Result<&'a [u8]> {
-        let length = cursor.read_u32()?;
+        let length = cursor.read_u32();
         let length = if length > 0 { length } else { 4 };
 
-        let key = cursor.read(length)?;
+        let key = cursor.read(length);
         Ok(key)
     }
 }

--- a/src/sections/layer_and_mask_information_section/layer.rs
+++ b/src/sections/layer_and_mask_information_section/layer.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::ops::{Deref, Range};
 
-use anyhow::Result;
 use thiserror::Error;
 
 use crate::psd_channel::IntoRgba;
@@ -195,15 +194,19 @@ pub struct PsdLayer {
 }
 
 /// An error when working with a PsdLayer
-#[derive(Debug, Error)]
+#[derive(Debug, PartialEq, Error)]
 pub enum PsdLayerError {
     #[error(
         r#"Could not combine Red, Green, Blue and Alpha.
         This layer is missing channel: {channel:#?}"#
     )]
     MissingChannels { channel: PsdChannelKind },
+    #[error("{channel_id} is an invalid channel id, must be 0, 1, 2, -1, -2, or -3.")]
+    InvalidChannel { channel_id: i16 },
     #[error(r#"Unknown blending mode: {mode:#?}"#)]
     UnknownBlendingMode { mode: [u8; 4] },
+    #[error("{compression} is an invalid layer channel compression. Must be 0, 1, 2 or 3")]
+    InvalidCompression { compression: u16 },
 }
 
 impl PsdLayer {
@@ -228,22 +231,24 @@ impl PsdLayer {
     }
 
     /// Get the compression level for one of this layer's channels
-    pub fn compression(&self, channel: PsdChannelKind) -> Result<PsdChannelCompression> {
+    pub fn compression(
+        &self,
+        channel: PsdChannelKind,
+    ) -> Result<PsdChannelCompression, PsdChannelError> {
         match self.channels.get(&channel) {
             Some(channel) => match channel {
                 ChannelBytes::RawData(_) => Ok(PsdChannelCompression::RawData),
                 ChannelBytes::RleCompressed(_) => Ok(PsdChannelCompression::RleCompressed),
             },
-            None => Err(PsdChannelError::ChannelNotFound { channel }.into()),
+            None => Err(PsdChannelError::ChannelNotFound { channel }),
         }
     }
 
     /// Create a vector that interleaves the red, green, blue and alpha channels in this PSD
     ///
     /// vec![R, G, B, A, R, G, B, A, ...]
-    pub fn rgba(&self) -> Result<Vec<u8>> {
-        let rgba = self.generate_rgba()?;
-        Ok(rgba)
+    pub fn rgba(&self) -> Vec<u8> {
+        self.generate_rgba()
     }
 
     // Get one of the PsdLayerChannels of this PsdLayer

--- a/src/sections/layer_and_mask_information_section/mod.rs
+++ b/src/sections/layer_and_mask_information_section/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::ops::Range;
 
-use failure::Error;
+use anyhow::Result;
 
 use crate::psd_channel::PsdChannelCompression;
 use crate::psd_channel::PsdChannelKind;
@@ -77,7 +77,7 @@ impl LayerAndMaskInformationSection {
         bytes: &[u8],
         psd_width: u32,
         psd_height: u32,
-    ) -> Result<LayerAndMaskInformationSection, Error> {
+    ) -> Result<LayerAndMaskInformationSection> {
         let mut cursor = PsdCursor::new(bytes);
 
         // The first four bytes of the section is the length marker for the layer and mask
@@ -121,7 +121,7 @@ impl LayerAndMaskInformationSection {
         layer_records: Vec<(LayerRecord, LayerChannels)>,
         group_count: usize,
         psd_size: (u32, u32),
-    ) -> Result<LayerAndMaskInformationSection, Error> {
+    ) -> Result<LayerAndMaskInformationSection> {
         let mut layers = NamedItems::with_capacity(layer_records.len());
         let mut groups: NamedItems<PsdGroup> = NamedItems::with_capacity(group_count);
 
@@ -202,7 +202,7 @@ impl LayerAndMaskInformationSection {
     fn read_layer_records(
         cursor: &mut PsdCursor,
         layer_count: u16,
-    ) -> Result<(usize, Vec<(LayerRecord, LayerChannels)>), Error> {
+    ) -> Result<(usize, Vec<(LayerRecord, LayerChannels)>)> {
         let mut groups_count = 0;
 
         let mut layer_records = vec![];
@@ -241,7 +241,7 @@ impl LayerAndMaskInformationSection {
         parent_id: u32,
         psd_size: (u32, u32),
         channels: LayerChannels,
-    ) -> Result<PsdLayer, Error> {
+    ) -> Result<PsdLayer> {
         Ok(PsdLayer::new(
             &layer_record,
             psd_size.0,
@@ -257,7 +257,7 @@ fn read_layer_channels(
     cursor: &mut PsdCursor,
     channel_data_lengths: &Vec<(PsdChannelKind, u32)>,
     scanlines: usize,
-) -> Result<LayerChannels, Error> {
+) -> Result<LayerChannels> {
     let capacity = channel_data_lengths.len();
     let mut channels = HashMap::with_capacity(capacity);
 
@@ -314,7 +314,7 @@ fn read_layer_channels(
 /// | Variable               | Layer mask data: See See Layer mask / adjustment layer data for structure. Can be 40 bytes, 24 bytes, or 4 bytes if no layer mask.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 /// | Variable               | Layer blending ranges: See See Layer blending ranges data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 /// | Variable               | Layer name: Pascal string, padded to a multiple of 4 bytes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-fn read_layer_record(cursor: &mut PsdCursor) -> Result<LayerRecord, Error> {
+fn read_layer_record(cursor: &mut PsdCursor) -> Result<LayerRecord> {
     let mut channel_data_lengths = vec![];
 
     // FIXME:

--- a/src/sections/layer_and_mask_information_section/mod.rs
+++ b/src/sections/layer_and_mask_information_section/mod.rs
@@ -87,10 +87,10 @@ impl LayerAndMaskInformationSection {
         // the exact number of bytes in the layer and information mask section of the PSD file,
         // so there's no way for us to accidentally read too many bytes. If we did the program
         // would panic.
-        cursor.read_4()?;
+        cursor.read_4();
 
         // Read the next four bytes to get the length of the layer info section.
-        let _layer_info_section_len = cursor.read_u32()?;
+        let _layer_info_section_len = cursor.read_u32();
 
         // Next 2 bytes is the layer count
         //
@@ -101,7 +101,7 @@ impl LayerAndMaskInformationSection {
         //
         // Layer count. If it is a negative number, its absolute value is the number of layers and
         // the first alpha channel contains the transparency data for the merged result.
-        let layer_count = cursor.read_i16()?;
+        let layer_count = cursor.read_i16();
 
         // TODO: If the layer count was negative we were supposed to treat the first alpha
         // channel as transparency data for the merged result.. So add a new test with a transparent
@@ -262,10 +262,10 @@ fn read_layer_channels(
     let mut channels = HashMap::with_capacity(capacity);
 
     for (channel_kind, channel_length) in channel_data_lengths.iter() {
-        let compression = cursor.read_u16()?;
+        let compression = cursor.read_u16();
         let compression = PsdChannelCompression::new(compression)?;
 
-        let channel_data = cursor.read(*channel_length)?;
+        let channel_data = cursor.read(*channel_length);
         let channel_bytes = match compression {
             PsdChannelCompression::RawData => ChannelBytes::RawData(channel_data.into()),
             PsdChannelCompression::RleCompressed => {
@@ -325,29 +325,29 @@ fn read_layer_record(cursor: &mut PsdCursor) -> Result<LayerRecord> {
     // Photoshop.
 
     // Read the rectangle that encloses the layer mask.
-    let top = cursor.read_i32()?;
+    let top = cursor.read_i32();
 
-    let left = cursor.read_i32()?;
+    let left = cursor.read_i32();
 
     // Subtract one in order to zero index. If a layer is fully transparent it's bottom will
     // already be 0 so we don't subtract
-    let bottom = cursor.read_i32()?;
+    let bottom = cursor.read_i32();
     let bottom = if bottom == 0 { 0 } else { bottom - 1 };
 
     // Subtract one in order to zero index. If a layer is fully transparent it's right will
     // already be zero so we don't subtract.
-    let right = cursor.read_i32()?;
+    let right = cursor.read_i32();
     let right = if right == 0 { 0 } else { right - 1 };
 
     // Get the number of channels in the layer
-    let channel_count = cursor.read_u16()?;
+    let channel_count = cursor.read_u16();
 
     // Read the channel information
     for _ in 0..channel_count {
-        let channel_id = cursor.read_i16()?;
+        let channel_id = cursor.read_i16();
         let channel_id = PsdChannelKind::new(channel_id)?;
 
-        let channel_length = cursor.read_u32()?;
+        let channel_length = cursor.read_u32();
         // The first two bytes encode the compression, the rest of the bytes
         // are the channel data.
         let channel_data_length = channel_length - 2;
@@ -356,18 +356,18 @@ fn read_layer_record(cursor: &mut PsdCursor) -> Result<LayerRecord> {
     }
 
     // We do not currently parse the blend mode signature, skip it
-    cursor.read_4()?;
+    cursor.read_4();
 
     let mut key = [0; 4];
-    key.copy_from_slice(cursor.read_4()?);
+    key.copy_from_slice(cursor.read_4());
     let blend_mode = match BlendMode::match_mode(key) {
         Some(v) => v,
         None => return Err(PsdLayerError::UnknownBlendingMode { mode: key }.into()),
     };
 
-    let opacity = cursor.read_u8()?;
+    let opacity = cursor.read_u8();
 
-    let clipping_base = cursor.read_u8()?;
+    let clipping_base = cursor.read_u8();
     let clipping_base = clipping_base == 0;
 
     // We do not currently parse all flags, only visible
@@ -377,25 +377,25 @@ fn read_layer_record(cursor: &mut PsdCursor) -> Result<LayerRecord> {
     //  - bit 2 = obsolete;
     //  - bit 3 = 1 for Photoshop 5.0 and later, tells if bit 4 has useful information;
     //  - bit 4 = pixel data irrelevant to appearance of document
-    let visible = cursor.read_u8()? & (1 << 1) != 0; // here we get second bit - visible
+    let visible = cursor.read_u8() & (1 << 1) != 0; // here we get second bit - visible
 
     // We do not currently parse the filter, skip it
-    cursor.read_1()?;
+    cursor.read_1();
 
     // We do not currently use the length of the extra data field, skip it
-    cursor.read_4()?;
+    cursor.read_4();
 
     // We do not currently use the layer mask data, skip it
-    let layer_mask_data_len = cursor.read_u32()?;
-    cursor.read(layer_mask_data_len)?;
+    let layer_mask_data_len = cursor.read_u32();
+    cursor.read(layer_mask_data_len);
 
     // We do not currently use the layer blending range, skip it
-    let layer_blending_range_data_len = cursor.read_u32()?;
-    cursor.read(layer_blending_range_data_len)?;
+    let layer_blending_range_data_len = cursor.read_u32();
+    cursor.read(layer_blending_range_data_len);
 
     // Read the layer name
-    let name_len = cursor.read_u8()?;
-    let name = cursor.read(name_len as u32)?;
+    let name_len = cursor.read_u8();
+    let name = cursor.read(name_len as u32);
     let name = String::from_utf8_lossy(name);
     let mut name = name.to_string();
 
@@ -406,39 +406,39 @@ fn read_layer_record(cursor: &mut PsdCursor) -> Result<LayerRecord> {
     // The 1 is the 1 byte that we read for the name length
     let bytes_mod_4 = (name_len + 1) % 4;
     let padding = (4 - bytes_mod_4) % 4;
-    cursor.read(padding as u32)?;
+    cursor.read(padding as u32);
 
     let mut divider_type = None;
     // There can be multiple additional layer information sections so we'll loop
     // until we stop seeing them.
-    while cursor.peek_4()? == SIGNATURE_EIGHT_BIM || cursor.peek_4()? == SIGNATURE_EIGHT_B64 {
-        let _signature = cursor.read_4()?;
+    while cursor.peek_4() == SIGNATURE_EIGHT_BIM || cursor.peek_4() == SIGNATURE_EIGHT_B64 {
+        let _signature = cursor.read_4();
         let mut key = [0; 4];
-        key.copy_from_slice(cursor.read_4()?);
-        let additional_layer_info_len = cursor.read_u32()?;
+        key.copy_from_slice(cursor.read_4());
+        let additional_layer_info_len = cursor.read_u32();
 
         match &key {
             KEY_UNICODE_LAYER_NAME => {
-                name = cursor.read_unicode_string()?;
+                name = cursor.read_unicode_string();
             }
             KEY_SECTION_DIVIDER_SETTING => {
-                divider_type = GroupDivider::match_divider(cursor.read_i32()?);
+                divider_type = GroupDivider::match_divider(cursor.read_i32());
 
                 // data present only if length >= 12
                 if additional_layer_info_len >= 12 {
-                    let _signature = cursor.read_4()?;
-                    let _key = cursor.read_4()?;
+                    let _signature = cursor.read_4();
+                    let _key = cursor.read_4();
                 }
 
                 // data present only if length >= 16
                 if additional_layer_info_len >= 16 {
-                    cursor.read_4()?;
+                    cursor.read_4();
                 }
             }
 
             // TODO: Skipping other keys until we implement parsing for them
             _ => {
-                cursor.read(additional_layer_info_len)?;
+                cursor.read(additional_layer_info_len);
             }
         }
     }

--- a/src/sections/mod.rs
+++ b/src/sections/mod.rs
@@ -1,7 +1,7 @@
-use std::io::Cursor;
-use anyhow::Result;
-use thiserror::Error;
 use crate::sections::file_header_section::{FileHeaderSectionError, EXPECTED_PSD_SIGNATURE};
+use anyhow::Result;
+use std::io::Cursor;
+use thiserror::Error;
 
 /// The length of the entire file header section
 const FILE_HEADER_SECTION_LEN: usize = 26;

--- a/src/sections/mod.rs
+++ b/src/sections/mod.rs
@@ -1,7 +1,6 @@
 use std::io::Cursor;
-
-use failure::{Error, Fail};
-
+use anyhow::Result;
+use thiserror::Error;
 use crate::sections::file_header_section::{FileHeaderSectionError, EXPECTED_PSD_SIGNATURE};
 
 /// The length of the entire file header section
@@ -58,7 +57,7 @@ impl<'a> MajorSections<'a> {
     /// A 4-byte length field, representing the number of characters in the string (not bytes).
     ///
     /// The string of Unicode values, two bytes per character.
-    pub fn from_bytes(bytes: &[u8]) -> Result<MajorSections, Error> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<MajorSections> {
         // File header section must be 26 bytes long.
         if bytes.len() < FILE_HEADER_SECTION_LEN {
             return Err(NotEnoughBytesError::FileHeader {
@@ -97,7 +96,7 @@ impl<'a> MajorSections<'a> {
 }
 
 /// Get the start and end indices of a major section
-fn read_major_section_start_end(cursor: &mut PsdCursor) -> Result<(usize, usize), Error> {
+fn read_major_section_start_end(cursor: &mut PsdCursor) -> Result<(usize, usize)> {
     let start = cursor.position() as usize;
     let data_len = cursor.read_u32()?;
     cursor.read(data_len)?;
@@ -110,13 +109,12 @@ fn read_major_section_start_end(cursor: &mut PsdCursor) -> Result<(usize, usize)
 ///
 /// For example, the FileHeaderSection requires 26 bytes, so if we only see
 /// 25 bytes we'll return an error.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum NotEnoughBytesError {
-    #[fail(
-        display = r#"Could not parse the file header section.
+    #[error(
+        r#"Could not parse the file header section.
     The file header section is comprised of the first 26 bytes (indices 0-25)
-    of a PSD file, but only {} total bytes were provided."#,
-        total_bytes
+    of a PSD file, but only {total_bytes} total bytes were provided."#
     )]
     FileHeader { total_bytes: usize },
 }
@@ -151,7 +149,7 @@ impl<'a> PsdCursor<'a> {
     }
 
     /// Advance the cursor by count bytes and return those bytes
-    pub fn read(&mut self, count: u32) -> Result<&[u8], Error> {
+    pub fn read(&mut self, count: u32) -> Result<&[u8]> {
         let start = self.cursor.position() as usize;
         let end = start + count as usize;
         let bytes = &self.cursor.get_ref()[start..end];
@@ -161,18 +159,18 @@ impl<'a> PsdCursor<'a> {
         Ok(bytes)
     }
 
-    pub fn peek_u32(&self) -> Result<u32, Error> {
+    pub fn peek_u32(&self) -> Result<u32> {
         let bytes = self.peek_4()?;
         Ok(u32_from_be_bytes(bytes))
     }
 
     /// Peek at the next four bytes
-    pub fn peek_4(&self) -> Result<&[u8], Error> {
+    pub fn peek_4(&self) -> Result<&[u8]> {
         self.peek(4)
     }
 
     /// Get the next n bytes without moving the cursor
-    fn peek(&self, n: u8) -> Result<&[u8], Error> {
+    fn peek(&self, n: u8) -> Result<&[u8]> {
         let start = self.cursor.position() as usize;
         let end = start + n as usize;
         let bytes = &self.cursor.get_ref()[start..end];
@@ -181,37 +179,37 @@ impl<'a> PsdCursor<'a> {
     }
 
     /// Read 1 byte
-    pub fn read_1(&mut self) -> Result<&[u8], Error> {
+    pub fn read_1(&mut self) -> Result<&[u8]> {
         self.read(1)
     }
 
     /// Read 2 bytes
-    pub fn read_2(&mut self) -> Result<&[u8], Error> {
+    pub fn read_2(&mut self) -> Result<&[u8]> {
         self.read(2)
     }
 
     /// Read 4 bytes
-    pub fn read_4(&mut self) -> Result<&[u8], Error> {
+    pub fn read_4(&mut self) -> Result<&[u8]> {
         self.read(4)
     }
 
     /// Read 6 bytes
-    pub fn read_6(&mut self) -> Result<&[u8], Error> {
+    pub fn read_6(&mut self) -> Result<&[u8]> {
         self.read(6)
     }
 
     /// Read 8 bytes
-    pub fn read_8(&mut self) -> Result<&[u8], Error> {
+    pub fn read_8(&mut self) -> Result<&[u8]> {
         self.read(8)
     }
 
     /// Read 1 byte as a u8
-    pub fn read_u8(&mut self) -> Result<u8, Error> {
+    pub fn read_u8(&mut self) -> Result<u8> {
         Ok(self.read_1()?[0])
     }
 
     /// Read 2 bytes as a u16
-    pub fn read_u16(&mut self) -> Result<u16, Error> {
+    pub fn read_u16(&mut self) -> Result<u16> {
         let bytes = self.read_2()?;
 
         let mut array = [0; 2];
@@ -221,13 +219,13 @@ impl<'a> PsdCursor<'a> {
     }
 
     /// Read 4 bytes as a u32
-    pub fn read_u32(&mut self) -> Result<u32, Error> {
+    pub fn read_u32(&mut self) -> Result<u32> {
         let bytes = self.read_4()?;
         Ok(u32_from_be_bytes(bytes))
     }
 
     /// Read 1 byte as a i8
-    pub fn read_i8(&mut self) -> Result<i8, Error> {
+    pub fn read_i8(&mut self) -> Result<i8> {
         let bytes = self.read_1()?;
 
         let mut array = [0; 1];
@@ -237,7 +235,7 @@ impl<'a> PsdCursor<'a> {
     }
 
     /// Read 2 bytes as a i16
-    pub fn read_i16(&mut self) -> Result<i16, Error> {
+    pub fn read_i16(&mut self) -> Result<i16> {
         let bytes = self.read_2()?;
 
         let mut array = [0; 2];
@@ -247,7 +245,7 @@ impl<'a> PsdCursor<'a> {
     }
 
     /// Read 4 bytes as a i32
-    pub fn read_i32(&mut self) -> Result<i32, Error> {
+    pub fn read_i32(&mut self) -> Result<i32> {
         let bytes = self.read_4()?;
 
         let mut array = [0; 4];
@@ -256,7 +254,7 @@ impl<'a> PsdCursor<'a> {
     }
 
     /// Read 8 bytes as a f64
-    pub fn read_f64(&mut self) -> Result<f64, Error> {
+    pub fn read_f64(&mut self) -> Result<f64> {
         let bytes = self.read_8()?;
 
         let mut array = [0; 8];
@@ -266,7 +264,7 @@ impl<'a> PsdCursor<'a> {
     }
 
     /// Read 8 bytes as a i64
-    pub fn read_i64(&mut self) -> Result<i64, Error> {
+    pub fn read_i64(&mut self) -> Result<i64> {
         let bytes = self.read_8()?;
 
         let mut array = [0; 8];
@@ -280,7 +278,7 @@ impl<'a> PsdCursor<'a> {
     /// Unicode string is
     /// A 4-byte length field, representing the number of UTF-16 code units in the string (not bytes).
     /// The string of Unicode values, two bytes per character and a two byte null for the end of the string.
-    pub fn read_unicode_string(&mut self) -> Result<String, Error> {
+    pub fn read_unicode_string(&mut self) -> Result<String> {
         self.read_unicode_string_padding(4)
     }
 
@@ -289,7 +287,7 @@ impl<'a> PsdCursor<'a> {
     /// Unicode string is
     /// A 4-byte length field, representing the number of UTF-16 code units in the string (not bytes).
     /// The string of Unicode values, two bytes per character and a two byte null for the end of the string.
-    pub fn read_unicode_string_padding(&mut self, padding: usize) -> Result<String, Error> {
+    pub fn read_unicode_string_padding(&mut self, padding: usize) -> Result<String> {
         let length = self.read_u32()? as usize;
         // UTF-16 encoding - two bytes per character
         let length_bytes = length * 2;
@@ -302,7 +300,7 @@ impl<'a> PsdCursor<'a> {
         Ok(result)
     }
 
-    fn read_padding(&mut self, size: usize, divisor: usize) -> Result<&[u8], Error> {
+    fn read_padding(&mut self, size: usize, divisor: usize) -> Result<&[u8]> {
         let remainder = size % divisor;
         if remainder > 0 {
             let to_read = divisor - remainder;
@@ -316,7 +314,7 @@ impl<'a> PsdCursor<'a> {
     ///
     /// Pascal string is UTF-8 string, padded to make the size even
     /// (a null name consists of two bytes of 0)
-    pub fn read_pascal_string(&mut self) -> Result<String, Error> {
+    pub fn read_pascal_string(&mut self) -> Result<String> {
         let len = self.read_u8()?;
         let data = self.read(len as u32)?;
         let result = Ok(String::from_utf8(data.to_vec())?);

--- a/src/sections/mod.rs
+++ b/src/sections/mod.rs
@@ -69,18 +69,18 @@ impl<'a> MajorSections<'a> {
         let mut cursor = PsdCursor::new(bytes);
 
         // First four bytes must be '8BPS'
-        let signature = cursor.peek_4()?;
+        let signature = cursor.peek_4();
         if signature != EXPECTED_PSD_SIGNATURE {
             return Err(FileHeaderSectionError::InvalidSignature {}.into());
         }
 
         // File Header Section
         let file_header = &bytes[0..FILE_HEADER_SECTION_LEN];
-        cursor.read(FILE_HEADER_SECTION_LEN as u32)?;
+        cursor.read(FILE_HEADER_SECTION_LEN as u32);
 
-        let (color_start, color_end) = read_major_section_start_end(&mut cursor)?;
-        let (img_res_start, img_res_end) = read_major_section_start_end(&mut cursor)?;
-        let (layer_mask_start, layer_mask_end) = read_major_section_start_end(&mut cursor)?;
+        let (color_start, color_end) = read_major_section_start_end(&mut cursor);
+        let (img_res_start, img_res_end) = read_major_section_start_end(&mut cursor);
+        let (layer_mask_start, layer_mask_end) = read_major_section_start_end(&mut cursor);
 
         // The remaining bytes are the image data section.
         let image_data = &bytes[cursor.position() as usize..];
@@ -96,13 +96,13 @@ impl<'a> MajorSections<'a> {
 }
 
 /// Get the start and end indices of a major section
-fn read_major_section_start_end(cursor: &mut PsdCursor) -> Result<(usize, usize)> {
+fn read_major_section_start_end(cursor: &mut PsdCursor) -> (usize, usize) {
     let start = cursor.position() as usize;
-    let data_len = cursor.read_u32()?;
-    cursor.read(data_len)?;
+    let data_len = cursor.read_u32();
+    cursor.read(data_len);
     let end = cursor.position() as usize;
 
-    Ok((start, end))
+    (start, end)
 }
 
 /// A section specified that it had more bytes than were provided.
@@ -149,128 +149,126 @@ impl<'a> PsdCursor<'a> {
     }
 
     /// Advance the cursor by count bytes and return those bytes
-    pub fn read(&mut self, count: u32) -> Result<&[u8]> {
+    pub fn read(&mut self, count: u32) -> &[u8] {
         let start = self.cursor.position() as usize;
         let end = start + count as usize;
         let bytes = &self.cursor.get_ref()[start..end];
 
         self.cursor.set_position(end as u64);
-
-        Ok(bytes)
+        bytes
     }
 
-    pub fn peek_u32(&self) -> Result<u32> {
-        let bytes = self.peek_4()?;
-        Ok(u32_from_be_bytes(bytes))
+    pub fn peek_u32(&self) -> u32 {
+        let bytes = self.peek_4();
+        u32_from_be_bytes(bytes)
     }
 
     /// Peek at the next four bytes
-    pub fn peek_4(&self) -> Result<&[u8]> {
+    pub fn peek_4(&self) -> &[u8] {
         self.peek(4)
     }
 
     /// Get the next n bytes without moving the cursor
-    fn peek(&self, n: u8) -> Result<&[u8]> {
+    fn peek(&self, n: u8) -> &[u8] {
         let start = self.cursor.position() as usize;
         let end = start + n as usize;
         let bytes = &self.cursor.get_ref()[start..end];
-
-        Ok(&bytes)
+        &bytes
     }
 
     /// Read 1 byte
-    pub fn read_1(&mut self) -> Result<&[u8]> {
+    pub fn read_1(&mut self) -> &[u8] {
         self.read(1)
     }
 
     /// Read 2 bytes
-    pub fn read_2(&mut self) -> Result<&[u8]> {
+    pub fn read_2(&mut self) -> &[u8] {
         self.read(2)
     }
 
     /// Read 4 bytes
-    pub fn read_4(&mut self) -> Result<&[u8]> {
+    pub fn read_4(&mut self) -> &[u8] {
         self.read(4)
     }
 
     /// Read 6 bytes
-    pub fn read_6(&mut self) -> Result<&[u8]> {
+    pub fn read_6(&mut self) -> &[u8] {
         self.read(6)
     }
 
     /// Read 8 bytes
-    pub fn read_8(&mut self) -> Result<&[u8]> {
+    pub fn read_8(&mut self) -> &[u8] {
         self.read(8)
     }
 
     /// Read 1 byte as a u8
-    pub fn read_u8(&mut self) -> Result<u8> {
-        Ok(self.read_1()?[0])
+    pub fn read_u8(&mut self) -> u8 {
+        self.read_1()[0]
     }
 
     /// Read 2 bytes as a u16
-    pub fn read_u16(&mut self) -> Result<u16> {
-        let bytes = self.read_2()?;
+    pub fn read_u16(&mut self) -> u16 {
+        let bytes = self.read_2();
 
         let mut array = [0; 2];
         array.copy_from_slice(bytes);
 
-        Ok(u16::from_be_bytes(array))
+        u16::from_be_bytes(array)
     }
 
     /// Read 4 bytes as a u32
-    pub fn read_u32(&mut self) -> Result<u32> {
-        let bytes = self.read_4()?;
-        Ok(u32_from_be_bytes(bytes))
+    pub fn read_u32(&mut self) -> u32 {
+        let bytes = self.read_4();
+        u32_from_be_bytes(bytes)
     }
 
     /// Read 1 byte as a i8
-    pub fn read_i8(&mut self) -> Result<i8> {
-        let bytes = self.read_1()?;
+    pub fn read_i8(&mut self) -> i8 {
+        let bytes = self.read_1();
 
         let mut array = [0; 1];
         array.copy_from_slice(bytes);
 
-        Ok(i8::from_be_bytes(array))
+        i8::from_be_bytes(array)
     }
 
     /// Read 2 bytes as a i16
-    pub fn read_i16(&mut self) -> Result<i16> {
-        let bytes = self.read_2()?;
+    pub fn read_i16(&mut self) -> i16 {
+        let bytes = self.read_2();
 
         let mut array = [0; 2];
         array.copy_from_slice(bytes);
 
-        Ok(i16::from_be_bytes(array))
+        i16::from_be_bytes(array)
     }
 
     /// Read 4 bytes as a i32
-    pub fn read_i32(&mut self) -> Result<i32> {
-        let bytes = self.read_4()?;
+    pub fn read_i32(&mut self) -> i32 {
+        let bytes = self.read_4();
 
         let mut array = [0; 4];
         array.copy_from_slice(bytes);
-        Ok(i32::from_be_bytes(array))
+        i32::from_be_bytes(array)
     }
 
     /// Read 8 bytes as a f64
-    pub fn read_f64(&mut self) -> Result<f64> {
-        let bytes = self.read_8()?;
+    pub fn read_f64(&mut self) -> f64 {
+        let bytes = self.read_8();
 
         let mut array = [0; 8];
         array.copy_from_slice(bytes);
 
-        Ok(f64::from_be_bytes(array))
+        f64::from_be_bytes(array)
     }
 
     /// Read 8 bytes as a i64
-    pub fn read_i64(&mut self) -> Result<i64> {
-        let bytes = self.read_8()?;
+    pub fn read_i64(&mut self) -> i64 {
+        let bytes = self.read_8();
 
         let mut array = [0; 8];
         array.copy_from_slice(bytes);
 
-        Ok(i64::from_be_bytes(array))
+        i64::from_be_bytes(array)
     }
 
     /// Reads 'Unicode string'
@@ -278,7 +276,7 @@ impl<'a> PsdCursor<'a> {
     /// Unicode string is
     /// A 4-byte length field, representing the number of UTF-16 code units in the string (not bytes).
     /// The string of Unicode values, two bytes per character and a two byte null for the end of the string.
-    pub fn read_unicode_string(&mut self) -> Result<String> {
+    pub fn read_unicode_string(&mut self) -> String {
         self.read_unicode_string_padding(4)
     }
 
@@ -287,26 +285,27 @@ impl<'a> PsdCursor<'a> {
     /// Unicode string is
     /// A 4-byte length field, representing the number of UTF-16 code units in the string (not bytes).
     /// The string of Unicode values, two bytes per character and a two byte null for the end of the string.
-    pub fn read_unicode_string_padding(&mut self, padding: usize) -> Result<String> {
-        let length = self.read_u32()? as usize;
+    pub fn read_unicode_string_padding(&mut self, padding: usize) -> String {
+        let length = self.read_u32() as usize;
         // UTF-16 encoding - two bytes per character
         let length_bytes = length * 2;
 
-        let data = self.read(length_bytes as u32)?;
-        let result = String::from_utf16(&u8_slice_to_u16(data).as_slice()[..length as usize])?;
+        let data = self.read(length_bytes as u32);
+        let result =
+            String::from_utf16(&u8_slice_to_u16(data).as_slice()[..length as usize]).unwrap();
 
-        self.read_padding(4 + length_bytes, padding)?;
+        self.read_padding(4 + length_bytes, padding);
 
-        Ok(result)
+        result
     }
 
-    fn read_padding(&mut self, size: usize, divisor: usize) -> Result<&[u8]> {
+    fn read_padding(&mut self, size: usize, divisor: usize) -> &[u8] {
         let remainder = size % divisor;
         if remainder > 0 {
             let to_read = divisor - remainder;
             self.read(to_read as u32)
         } else {
-            Ok(&[] as &[u8])
+            &[] as &[u8]
         }
     }
 
@@ -314,13 +313,13 @@ impl<'a> PsdCursor<'a> {
     ///
     /// Pascal string is UTF-8 string, padded to make the size even
     /// (a null name consists of two bytes of 0)
-    pub fn read_pascal_string(&mut self) -> Result<String> {
-        let len = self.read_u8()?;
-        let data = self.read(len as u32)?;
-        let result = Ok(String::from_utf8(data.to_vec())?);
+    pub fn read_pascal_string(&mut self) -> String {
+        let len = self.read_u8();
+        let data = self.read(len as u32);
+        let result = String::from_utf8(data.to_vec()).unwrap();
 
         // read null byte
-        self.read_u8()?;
+        self.read_u8();
         result
     }
 }

--- a/tests/blend.rs
+++ b/tests/blend.rs
@@ -1,7 +1,7 @@
 //! FIXME: Combine these all into one test that iterates through a vector of
 //! (PathBuf, [f32; 4])
 
-use failure::Error;
+use anyhow::Result;
 use psd::Psd;
 
 const BLEND_NORMAL_BLUE_RED_PIXEL: [u8; 4] = [85, 0, 170, 192];
@@ -33,7 +33,7 @@ const BLEND_EXCLUSION_BLUE_RED_PIXEL: [u8; 4] = [170, 0, 170, 192];
 
 /// cargo test --test blend normal -- --exact
 #[test]
-fn normal() -> Result<(), Error> {
+fn normal() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-normal.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -45,7 +45,7 @@ fn normal() -> Result<(), Error> {
 
 /// cargo test --test blend multiply -- --exact
 #[test]
-fn multiply() -> Result<(), Error> {
+fn multiply() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-multiply.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -57,7 +57,7 @@ fn multiply() -> Result<(), Error> {
 
 /// cargo test --test blend screen -- --exact
 #[test]
-fn screen() -> Result<(), Error> {
+fn screen() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-screen.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -69,7 +69,7 @@ fn screen() -> Result<(), Error> {
 
 /// cargo test --test blend overlay -- --exact
 #[test]
-fn overlay() -> Result<(), Error> {
+fn overlay() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-overlay.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -81,7 +81,7 @@ fn overlay() -> Result<(), Error> {
 
 /// cargo test --test blend darken -- --exact
 #[test]
-fn darken() -> Result<(), Error> {
+fn darken() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-darken.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -93,7 +93,7 @@ fn darken() -> Result<(), Error> {
 
 /// cargo test --test blend lighten -- --exact
 #[test]
-fn lighten() -> Result<(), Error> {
+fn lighten() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-lighten.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -105,7 +105,7 @@ fn lighten() -> Result<(), Error> {
 
 /// cargo test --test blend color_burn -- --exact
 #[test]
-fn color_burn() -> Result<(), Error> {
+fn color_burn() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-color-burn.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -117,7 +117,7 @@ fn color_burn() -> Result<(), Error> {
 
 /// cargo test --test blend color_dodge -- --exact
 #[test]
-fn color_dodge() -> Result<(), Error> {
+fn color_dodge() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-color-dodge.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -129,7 +129,7 @@ fn color_dodge() -> Result<(), Error> {
 
 /// cargo test --test blend linear_burn -- --exact
 #[test]
-fn linear_burn() -> Result<(), Error> {
+fn linear_burn() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-linear-burn.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -141,7 +141,7 @@ fn linear_burn() -> Result<(), Error> {
 
 /// cargo test --test blend linear_dodge -- --exact
 #[test]
-fn linear_dodge() -> Result<(), Error> {
+fn linear_dodge() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-linear-dodge.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -153,7 +153,7 @@ fn linear_dodge() -> Result<(), Error> {
 
 /// cargo test --test blend hard_light -- --exact
 #[test]
-fn hard_light() -> Result<(), Error> {
+fn hard_light() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-hard-light.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -165,7 +165,7 @@ fn hard_light() -> Result<(), Error> {
 
 /// cargo test --test blend soft_light -- --exact
 #[test]
-fn soft_light() -> Result<(), Error> {
+fn soft_light() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-soft-light.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -177,7 +177,7 @@ fn soft_light() -> Result<(), Error> {
 
 /// cargo test --test blend divide -- --exact
 #[test]
-fn divide() -> Result<(), Error> {
+fn divide() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-divide.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -189,7 +189,7 @@ fn divide() -> Result<(), Error> {
 
 /// cargo test --test blend subtract -- --exact
 #[test]
-fn subtract() -> Result<(), Error> {
+fn subtract() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-subtract.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -201,7 +201,7 @@ fn subtract() -> Result<(), Error> {
 
 /// cargo test --test blend difference -- --exact
 #[test]
-fn difference() -> Result<(), Error> {
+fn difference() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-difference.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -213,7 +213,7 @@ fn difference() -> Result<(), Error> {
 
 /// cargo test --test blend exclusion -- --exact
 #[test]
-fn exclusion() -> Result<(), Error> {
+fn exclusion() -> Result<()> {
     let psd = include_bytes!("./fixtures/blending/blue-red-1x1-exclusion.psd");
     let psd = Psd::from_bytes(psd)?;
 

--- a/tests/channels.rs
+++ b/tests/channels.rs
@@ -1,11 +1,11 @@
-use failure::Error;
+use anyhow::Result;
 use psd::ColorMode;
 use psd::Psd;
 use psd::PsdDepth;
 
 /// cargo test --test channels one_channel_grayscale_raw_data -- --exact
 #[test]
-fn one_channel_grayscale_raw_data() -> Result<(), Error> {
+fn one_channel_grayscale_raw_data() -> Result<()> {
     let psd = include_bytes!("./fixtures/one-channel-1x1.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -32,7 +32,7 @@ fn one_channel_grayscale_raw_data() -> Result<(), Error> {
 ///
 /// cargo test --test channels two_channel_grayscale_raw_data -- --exact
 #[test]
-fn two_channel_grayscale_raw_data() -> Result<(), Error> {
+fn two_channel_grayscale_raw_data() -> Result<()> {
     let psd = include_bytes!("./fixtures/two-channel-8x8.psd");
     let psd = Psd::from_bytes(psd)?;
 

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Result;
 use psd::{Psd, PsdChannelCompression};
 
 const RED_PIXEL: [u8; 4] = [255, 0, 0, 255];
@@ -7,7 +7,7 @@ const BLUE_PIXEL: [u8; 4] = [0, 0, 255, 255];
 
 /// cargo test --test compression rle_decompress_final_image -- --exact
 #[test]
-fn rle_decompress_final_image() -> Result<(), Error> {
+fn rle_decompress_final_image() -> Result<()> {
     let psd = include_bytes!("./fixtures/rle-3-layer-8x8.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -23,7 +23,7 @@ fn rle_decompress_final_image() -> Result<(), Error> {
 
 /// cargo test --test compression rle_decompress_layer -- --exact
 #[test]
-fn rle_decompress_layer() -> Result<(), Error> {
+fn rle_decompress_layer() -> Result<()> {
     let psd = include_bytes!("./fixtures/rle-3-layer-8x8.psd");
     let psd = Psd::from_bytes(psd)?;
 

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -42,7 +42,7 @@ fn rle_decompress_layer() -> Result<()> {
 
 fn test_rle_layer(psd: &Psd, layer_name: &str, expected_pixels: &[u8]) {
     let layer = psd.layer_by_name(layer_name).unwrap();
-    assert_eq!(&layer.rgba().unwrap().as_slice(), &expected_pixels);
+    assert_eq!(&layer.rgba().as_slice(), &expected_pixels);
 }
 
 // Below are methods to make different expected final pixels so that we can text our generated

--- a/tests/file_header_section.rs
+++ b/tests/file_header_section.rs
@@ -1,10 +1,10 @@
-use failure::Error;
+use anyhow::Result;
 use psd::PsdDepth;
 use psd::{ColorMode, Psd};
 
 /// cargo test --test file_header_section file_header_section -- --exact
 #[test]
-fn file_header_section() -> Result<(), Error> {
+fn file_header_section() -> Result<()> {
     let psd = include_bytes!("./fixtures/green-1x1.psd");
 
     let psd = Psd::from_bytes(psd)?;
@@ -21,7 +21,7 @@ fn file_header_section() -> Result<(), Error> {
 
 /// cargo test --test file_header_section negative_top_left -- --exact
 #[test]
-fn negative_top_left() -> Result<(), Error> {
+fn negative_top_left() -> Result<()> {
     let psd = include_bytes!("./fixtures/negative-top-left-layer.psd");
 
     let psd = Psd::from_bytes(psd)?;

--- a/tests/flatten_layers.rs
+++ b/tests/flatten_layers.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use psd::Psd;
 
 const RED_PIXEL: [u8; 4] = [255, 0, 0, 255];
@@ -8,7 +9,7 @@ const BLUE_PIXEL: [u8; 4] = [0, 0, 255, 255];
 ///
 /// cargo test --test flatten_layers flatten_fully_transparent_pixel_replaced_by_pixel_below -- --exact
 #[test]
-fn flatten_fully_transparent_pixel_replaced_by_pixel_below() -> Result<(), failure::Error> {
+fn flatten_fully_transparent_pixel_replaced_by_pixel_below() -> Result<()> {
     let psd = include_bytes!("./fixtures/transparent-top-layer-2x1.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -27,7 +28,7 @@ fn flatten_fully_transparent_pixel_replaced_by_pixel_below() -> Result<(), failu
 ///
 /// cargo test --test flatten_layers no_matching_layers -- --exact
 #[test]
-fn no_matching_layers() -> Result<(), failure::Error> {
+fn no_matching_layers() -> Result<()> {
     let psd = include_bytes!("./fixtures/transparent-top-layer-2x1.psd");
     let psd = Psd::from_bytes(psd)?;
 

--- a/tests/layer_and_mask_information_section.rs
+++ b/tests/layer_and_mask_information_section.rs
@@ -13,7 +13,7 @@ fn layer_and_mask_information_section() {
 
     let layer = psd.layer_by_name("First Layer").unwrap();
 
-    assert_eq!(&layer.rgba().unwrap()[..], &GREEN_PIXEL);
+    assert_eq!(&layer.rgba()[..], &GREEN_PIXEL);
 }
 
 /// cargo test --test layer_and_mask_information_section layer_with_cyrillic_name -- --exact

--- a/tests/transparency.rs
+++ b/tests/transparency.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use psd::Psd;
 use psd::PsdChannelCompression;
 use psd::PsdChannelKind;
@@ -26,7 +26,9 @@ fn transparency_raw_data() -> Result<()> {
     assert_colors(psd.rgba(), &psd, &blue_pixels);
 
     assert_colors(
-        psd.layer_by_name("OpaqueCenter")?.rgba()?,
+        psd.layer_by_name("OpaqueCenter")
+            .ok_or(anyhow!("layer not found"))?
+            .rgba(),
         &psd,
         &blue_pixels,
     );
@@ -53,12 +55,19 @@ fn transparency_rle_compressed() -> Result<()> {
     assert_colors(psd.rgba(), &psd, &red_block);
 
     assert_eq!(
-        psd.layer_by_name("OpaqueCenter")?
+        psd.layer_by_name("OpaqueCenter")
+            .ok_or(anyhow!("layer not found"))?
             .compression(PsdChannelKind::Red)?,
         PsdChannelCompression::RleCompressed
     );
 
-    assert_colors(psd.layer_by_name("OpaqueCenter")?.rgba()?, &psd, &red_block);
+    assert_colors(
+        psd.layer_by_name("OpaqueCenter")
+            .ok_or(anyhow!("layer not found"))?
+            .rgba(),
+        &psd,
+        &red_block,
+    );
 
     Ok(())
 }

--- a/tests/transparency.rs
+++ b/tests/transparency.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Result;
 use psd::Psd;
 use psd::PsdChannelCompression;
 use psd::PsdChannelKind;
@@ -17,7 +17,7 @@ const BLUE_PIXEL: [u8; 4] = [0, 0, 255, 255];
 // Test that images that have transparent pixels and don't use compression
 // return the correct RGBA
 #[test]
-fn transparency_raw_data() -> Result<(), failure::Error> {
+fn transparency_raw_data() -> Result<()> {
     let psd = include_bytes!("./fixtures/3x3-opaque-center.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -37,7 +37,7 @@ fn transparency_raw_data() -> Result<(), failure::Error> {
 // Test that images that have transparent pixels and use rle compression
 // return the correct RGBA
 #[test]
-fn transparency_rle_compressed() -> Result<(), failure::Error> {
+fn transparency_rle_compressed() -> Result<()> {
     let psd = include_bytes!("./fixtures/16x16-rle-partially-opaque.psd");
     let psd = Psd::from_bytes(psd)?;
 
@@ -66,7 +66,7 @@ fn transparency_rle_compressed() -> Result<(), failure::Error> {
 // Fixes an `already borrowed: BorrowMutError` that we were getting in the `flattened_pixel`
 // method when we were recursing into the method and trying to borrow when we'd already borrowed.
 #[test]
-fn transparent_above_opaque() -> Result<(), Error> {
+fn transparent_above_opaque() -> Result<()> {
     let psd = include_bytes!("./fixtures/transparent-above-opaque.psd");
     let psd = Psd::from_bytes(psd)?;
 


### PR DESCRIPTION
# Summary

This PR replaces [`failure`](https://github.com/rust-lang-deprecated/failure) crate with [`thiserror`](https://github.com/dtolnay/thiserror) and [`anyhow`](https://github.com/dtolnay/anyhow) crates as suggested in [failure README.MD](https://github.com/rust-lang-deprecated/failure#failure---a-new-error-management-story)

# Problem

`failure` crate is deprecated therefore running `cargo-deny check` projects using [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) reports `unmaintained`.

Moreover it reports possible memory safety issues (reports `unsound`). 

For more info on both issues see https://github.com/rustsec/advisory-db/tree/main/crates/failure.