### PR TITLE
Relax `thiserror` and `anyhow` version specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/chinedufn/psd"
 edition = "2018"
 
 [dependencies]
-thiserror = "1.0"
+thiserror = "1"
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = "1"
 
 [workspace]
 members = [

--- a/examples/drag-drop-browser/src/lib.rs
+++ b/examples/drag-drop-browser/src/lib.rs
@@ -53,7 +53,7 @@ impl AppWrapper {
 
                     store.borrow_mut().msg(&Msg::SetIsRendering(false));
                 };
-                let mut re_render = Closure::wrap(Box::new(re_render) as Box<FnMut()>);
+                let mut re_render = Closure::wrap(Box::new(re_render) as Box<dyn FnMut()>);
 
                 window().request_animation_frame(&re_render.as_ref().unchecked_ref());
 


### PR DESCRIPTION
This allow specificaly to use a more recent version of `thiserror` that use `syn@2` as dependency