### PR TITLE
Add Tree structure and traversal 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::sections::image_resources_section::{DescriptorField, UnitFloatStr
 pub use crate::sections::layer_and_mask_information_section::layer::PsdGroup;
 pub use crate::sections::layer_and_mask_information_section::layer::PsdLayer;
 pub use crate::sections::layer_and_mask_information_section::{
-    LayerAndMaskInformationSection, NodeAction, NodeType, PsdNode,
+    LayerAndMaskInformationSection, NodeType, PsdNode,
 };
 use crate::sections::MajorSections;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::sections::image_resources_section::{DescriptorField, UnitFloatStr
 pub use crate::sections::layer_and_mask_information_section::layer::PsdGroup;
 pub use crate::sections::layer_and_mask_information_section::layer::PsdLayer;
 pub use crate::sections::layer_and_mask_information_section::{
-    LayerAndMaskInformationSection, NodeAction, PsdNode,
+    LayerAndMaskInformationSection, NodeAction, NodeType, PsdNode,
 };
 use crate::sections::MajorSections;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ use crate::sections::image_resources_section::ImageResourcesSection;
 pub use crate::sections::image_resources_section::{DescriptorField, UnitFloatStructure};
 pub use crate::sections::layer_and_mask_information_section::layer::PsdGroup;
 pub use crate::sections::layer_and_mask_information_section::layer::PsdLayer;
-use crate::sections::layer_and_mask_information_section::{
-    LayerAndMaskInformationSection, PsdNode,
+pub use crate::sections::layer_and_mask_information_section::{
+    LayerAndMaskInformationSection, NodeAction, PsdNode,
 };
 use crate::sections::MajorSections;
 
@@ -266,6 +266,19 @@ impl Psd {
     /// Returns the PSD group/layer tree
     pub fn tree(&self) -> &PsdNode {
         &self.layer_and_mask_information_section.tree
+    }
+
+    /// execute a function for every node in the tree
+    pub fn traverse_tree<F>(&self, node_index: usize, depth: usize, action: &F)
+    where
+        F: Fn(&PsdNode, usize),
+    {
+        let node = &self.layer_and_mask_information_section.nodes[node_index];
+        action(node, depth);
+
+        for &child_index in node.children() {
+            self.traverse_tree(child_index, depth + 1, action);
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@ use crate::sections::image_resources_section::ImageResourcesSection;
 pub use crate::sections::image_resources_section::{DescriptorField, UnitFloatStructure};
 pub use crate::sections::layer_and_mask_information_section::layer::PsdGroup;
 pub use crate::sections::layer_and_mask_information_section::layer::PsdLayer;
-use crate::sections::layer_and_mask_information_section::LayerAndMaskInformationSection;
+use crate::sections::layer_and_mask_information_section::{
+    LayerAndMaskInformationSection, PsdNode,
+};
 use crate::sections::MajorSections;
 
 use self::sections::file_header_section::FileHeaderSection;
@@ -259,6 +261,11 @@ impl Psd {
         }
 
         Ok(flattened_pixels)
+    }
+
+    /// Returns the PSD group/layer tree
+    pub fn tree(&self) -> &PsdNode {
+        &self.layer_and_mask_information_section.tree
     }
 }
 

--- a/src/sections/layer_and_mask_information_section/mod.rs
+++ b/src/sections/layer_and_mask_information_section/mod.rs
@@ -94,7 +94,7 @@ pub struct LayerAndMaskInformationSection {
 }
 
 /// Frame represents a group stack frame
-#[derive(Debug, Clone)] // Add Clone here
+#[derive(Debug, Clone)]
 struct Frame {
     start_idx: usize,
     name: String,
@@ -173,6 +173,7 @@ impl LayerAndMaskInformationSection {
             children: vec![],
         }));
 
+        // Create stack with root-level
         let mut stack: Vec<Frame> = vec![Frame {
             start_idx: 0,
             name: String::from("root"),
@@ -182,11 +183,14 @@ impl LayerAndMaskInformationSection {
         let mut tree_stack: Vec<Rc<RefCell<PsdNode>>> = vec![Rc::clone(&root)];
         let mut already_viewed = 0;
 
+        // Read each layer's channel image data
         for (layer_record, channels) in layer_records.into_iter() {
+            // get current group from stack
             let current_group_id = stack.last().unwrap().group_id;
             let current_tree_node = tree_stack.last().unwrap().clone();
 
             match layer_record.divider_type {
+                // open the folder
                 Some(GroupDivider::CloseFolder) | Some(GroupDivider::OpenFolder) => {
                     already_viewed += 1;
 
@@ -208,6 +212,7 @@ impl LayerAndMaskInformationSection {
                         .push(Rc::clone(&group_node));
                     tree_stack.push(group_node);
                 }
+                // close the folder
                 Some(GroupDivider::BoundingSection) => {
                     let frame = stack.pop().unwrap();
                     let group_node = tree_stack.pop().unwrap();

--- a/src/sections/layer_and_mask_information_section/mod.rs
+++ b/src/sections/layer_and_mask_information_section/mod.rs
@@ -37,17 +37,6 @@ pub enum NodeType {
     Layer(PsdLayer),
 }
 
-// A struct to hold the borrowed data and provide access to the content
-pub struct BorrowedNodeContent<'a> {
-    node_ref: Ref<'a, PsdNode>,
-}
-
-impl<'a> BorrowedNodeContent<'a> {
-    pub fn content(&self) -> Option<&NodeType> {
-        self.node_ref.content.as_ref()
-    }
-}
-
 /// Struct used to define PSD tree nodes and children
 #[derive(Default, Debug, Clone)]
 pub struct PsdNode {
@@ -69,11 +58,6 @@ impl PsdNode {
         self.children.get(index).cloned()
     }
 }
-
-// Define a type alias for the closure that will be applied to each node.
-// The closure takes a reference to a PsdNode and returns nothing.
-/// Lmabda type for node traversal
-pub type NodeAction<'a> = Box<dyn Fn(&PsdNode, usize) + 'a>; // Now also takes the depth as an argument
 
 /// The LayerAndMaskInformationSection comes from the bytes in the fourth section of the PSD.
 ///

--- a/src/sections/layer_and_mask_information_section/mod.rs
+++ b/src/sections/layer_and_mask_information_section/mod.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 use std::collections::HashMap;
 use std::ops::Range;
 use std::rc::Rc;
@@ -37,6 +37,17 @@ pub enum NodeType {
     Layer(PsdLayer),
 }
 
+// A struct to hold the borrowed data and provide access to the content
+pub struct BorrowedNodeContent<'a> {
+    node_ref: Ref<'a, PsdNode>,
+}
+
+impl<'a> BorrowedNodeContent<'a> {
+    pub fn content(&self) -> Option<&NodeType> {
+        self.node_ref.content.as_ref()
+    }
+}
+
 /// Struct used to define PSD tree nodes and children
 #[derive(Default, Debug, Clone)]
 pub struct PsdNode {
@@ -51,6 +62,11 @@ impl PsdNode {
     /// returns PsdNode children PsdNode
     pub fn children(&self) -> Vec<Rc<RefCell<PsdNode>>> {
         self.children.clone()
+    }
+
+    /// Gets a reference to a child node at a given index.
+    pub fn child(&self, index: usize) -> Option<Rc<RefCell<PsdNode>>> {
+        self.children.get(index).cloned()
     }
 }
 

--- a/tests/layer_groups.rs
+++ b/tests/layer_groups.rs
@@ -1,4 +1,4 @@
-use psd::{NodeAction, NodeType, Psd, PsdGroup};
+use psd::{NodeType, Psd, PsdGroup};
 const TOP_LEVEL_ID: u32 = 1;
 
 /// Verify that we can get a group by it's ID.

--- a/tests/layer_groups.rs
+++ b/tests/layer_groups.rs
@@ -1,4 +1,4 @@
-use psd::{Psd, PsdGroup};
+use psd::{NodeAction, Psd, PsdGroup, PsdNode};
 const TOP_LEVEL_ID: u32 = 1;
 
 /// Verify that we can get a group by it's ID.
@@ -122,6 +122,24 @@ fn one_group_with_two_subgroups() {
 
     let layer = psd.layer_by_name("Sixth Layer").unwrap();
     assert_eq!(layer.parent_id().unwrap(), outside_group.id());
+}
+
+/// cargo test --test layer_and_mask_information_section tree_one_group_with_two_subgroups -- --exact
+#[test]
+fn tree_one_group_with_two_subgroups() {
+    let psd = include_bytes!("fixtures/groups/green-1x1-one-group-with-two-subgroups.psd");
+    let psd = Psd::from_bytes(psd).unwrap();
+
+    let print_node_name: NodeAction = Box::new(|node, depth| {
+        let indentation = " ".repeat(depth * 4); // 4 spaces per depth level
+        match &node.content {
+            Some(NodeType::Group(group)) => println!("{}Group: {}", indentation, group.name()),
+            Some(NodeType::Layer(layer)) => println!("{}Layer: {}", indentation, layer.name()),
+            None => println!("{}Root Node", indentation),
+        }
+    });
+
+    psd.traverse_tree(0, 0, &print_node_name);
 }
 
 /// Verify that we can properly load an RLEcompressed empty channel (caused by a group from GIMP)

--- a/tests/layer_groups.rs
+++ b/tests/layer_groups.rs
@@ -1,4 +1,4 @@
-use psd::{NodeAction, Psd, PsdGroup, PsdNode};
+use psd::{NodeAction, NodeType, Psd, PsdGroup};
 const TOP_LEVEL_ID: u32 = 1;
 
 /// Verify that we can get a group by it's ID.
@@ -130,9 +130,10 @@ fn tree_one_group_with_two_subgroups() {
     let psd = include_bytes!("fixtures/groups/green-1x1-one-group-with-two-subgroups.psd");
     let psd = Psd::from_bytes(psd).unwrap();
 
+    let tree_output = "";
     let print_node_name: NodeAction = Box::new(|node, depth| {
         let indentation = " ".repeat(depth * 4); // 4 spaces per depth level
-        match &node.content {
+        match &node.content() {
             Some(NodeType::Group(group)) => println!("{}Group: {}", indentation, group.name()),
             Some(NodeType::Layer(layer)) => println!("{}Layer: {}", indentation, layer.name()),
             None => println!("{}Root Node", indentation),
@@ -140,6 +141,7 @@ fn tree_one_group_with_two_subgroups() {
     });
 
     psd.traverse_tree(0, 0, &print_node_name);
+    assert_eq!(psd.tree().children()[0], 420);
 }
 
 /// Verify that we can properly load an RLEcompressed empty channel (caused by a group from GIMP)

--- a/tests/layer_groups.rs
+++ b/tests/layer_groups.rs
@@ -129,19 +129,15 @@ fn one_group_with_two_subgroups() {
 fn tree_one_group_with_two_subgroups() {
     let psd = include_bytes!("fixtures/groups/green-1x1-one-group-with-two-subgroups.psd");
     let psd = Psd::from_bytes(psd).unwrap();
-
-    let tree_output = "";
-    let print_node_name: NodeAction = Box::new(|node, depth| {
-        let indentation = " ".repeat(depth * 4); // 4 spaces per depth level
-        match &node.content() {
-            Some(NodeType::Group(group)) => println!("{}Group: {}", indentation, group.name()),
-            Some(NodeType::Layer(layer)) => println!("{}Layer: {}", indentation, layer.name()),
-            None => println!("{}Root Node", indentation),
+    psd.traverse(|node, depth| {
+        let indent = " ".repeat(depth * 4); // 4 spaces per depth level
+        if let Some(content) = &node.content() {
+            match content {
+                NodeType::Group(group) => println!("{}Group: {}", indent, group.name()),
+                NodeType::Layer(layer) => println!("{}Layer: {}", indent, layer.name()),
+            }
         }
     });
-
-    psd.traverse_tree(0, 0, &print_node_name);
-    assert_eq!(psd.tree().children()[0], 420);
 }
 
 /// Verify that we can properly load an RLEcompressed empty channel (caused by a group from GIMP)


### PR DESCRIPTION
This PR adds a tree structure that represents the Psd layer tree. This PR preserves the existing layer and group interfaces. I added this tree feature because I needed a more intuitive way to navigate the three without knowing the group name in advanced. Also was finding it hard to construct a tree externally and maintain sort order on a hierarchy level that had mixed groups and layers using the existing group and layer. Needed to construct the tree at decode time to persevere the order. This PR also adds a test that copies `one_group_with_two_subgroups` test but uses the tree interface to navigate.