### PR TITLE
ICC Profile support & 16 bit crash fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,15 @@ impl Psd {
     pub fn resources(&self) -> &Vec<ImageResource> {
         &self.image_resources_section.resources
     }
+
+    /// The ICC color profile embedded in the PSD file, if any.
+    ///
+    /// This corresponds to image resource ID 1039 in the PSD specification.
+    /// The returned bytes are the raw ICC profile data, suitable for embedding
+    /// in output formats (e.g. JPEG APP2 marker).
+    pub fn icc_profile(&self) -> Option<&[u8]> {
+        self.image_resources_section.icc_profile.as_deref()
+    }
 }
 
 impl IntoRgba for Psd {

--- a/src/psd_channel.rs
+++ b/src/psd_channel.rs
@@ -127,7 +127,9 @@ pub trait IntoRgba {
 
                 for (idx, byte) in channel_bytes.iter().enumerate() {
                     if let Some(rgba_idx) = self.rgba_idx(idx) {
-                        rgba[rgba_idx * 4 + offset] = *byte;
+                        if let Some(buffer) = rgba.get_mut(rgba_idx * 4 + offset) {
+                            *buffer = *byte;
+                        }
                     }
                 }
             }

--- a/src/sections/image_data_section.rs
+++ b/src/sections/image_data_section.rs
@@ -104,12 +104,40 @@ impl ImageDataSection {
                     // currently only support one byte per pixel so we convert the 2 bytes
                     // back down into 1 byte by mapping 0-65535 down to 0-255
                     PsdDepth::Sixteen => {
-                        for idx in 0..red.len() / 2 {
-                            let bytes = [red[2 * idx], red[2 * idx + 1]];
-                            let bits16 = u16::from_be_bytes(bytes);
-                            red[idx] = (bits16 / 256) as u8;
+                        // Convert all channels from 16-bit to 8-bit by mapping
+                        // 0-65535 down to 0-255.
+                        fn convert_16_to_8(buf: &mut Vec<u8>) {
+                            for idx in 0..buf.len() / 2 {
+                                let bytes = [buf[2 * idx], buf[2 * idx + 1]];
+                                let bits16 = u16::from_be_bytes(bytes);
+                                buf[idx] = (bits16 / 256) as u8;
+                            }
+                            buf.truncate(buf.len() / 2);
                         }
-                        red.truncate(red.len() / 2);
+
+                        convert_16_to_8(&mut red);
+
+                        let green = green.map(|ch| match ch {
+                            ChannelBytes::RawData(mut data) => {
+                                convert_16_to_8(&mut data);
+                                ChannelBytes::RawData(data)
+                            }
+                            other => other,
+                        });
+                        let blue = blue.map(|ch| match ch {
+                            ChannelBytes::RawData(mut data) => {
+                                convert_16_to_8(&mut data);
+                                ChannelBytes::RawData(data)
+                            }
+                            other => other,
+                        });
+                        let alpha = alpha.map(|ch| match ch {
+                            ChannelBytes::RawData(mut data) => {
+                                convert_16_to_8(&mut data);
+                                ChannelBytes::RawData(data)
+                            }
+                            other => other,
+                        });
 
                         (ChannelBytes::RawData(red), green, blue, alpha)
                     }

--- a/src/sections/image_resources_section.rs
+++ b/src/sections/image_resources_section.rs
@@ -10,6 +10,7 @@ use crate::sections::PsdCursor;
 const EXPECTED_RESOURCE_BLOCK_SIGNATURE: [u8; 4] = [56, 66, 73, 77];
 const EXPECTED_DESCRIPTOR_VERSION: u32 = 16;
 const RESOURCE_SLICES_INFO: i16 = 1050;
+const RESOURCE_ICC_PROFILE: i16 = 1039;
 
 mod image_resource;
 
@@ -22,6 +23,7 @@ struct ImageResourcesBlock {
 #[derive(Debug)]
 pub struct ImageResourcesSection {
     pub(crate) resources: Vec<ImageResource>,
+    pub(crate) icc_profile: Option<Vec<u8>>,
 }
 
 /// Represents an malformed resource block
@@ -42,6 +44,7 @@ impl ImageResourcesSection {
         let mut cursor = PsdCursor::new(bytes);
 
         let mut resources = vec![];
+        let mut icc_profile = None;
 
         let length = cursor.read_u32() as u64;
 
@@ -57,13 +60,16 @@ impl ImageResourcesSection {
                     .map_err(ImageResourcesSectionError::InvalidResource)?;
                     resources.push(ImageResource::Slices(slices_image_resource));
                 }
+                _ if rid == RESOURCE_ICC_PROFILE => {
+                    icc_profile = Some(cursor.get_ref()[block.data_range].to_vec());
+                }
                 _ => {}
             }
         }
 
         assert_eq!(cursor.position(), length + 4);
 
-        Ok(ImageResourcesSection { resources })
+        Ok(ImageResourcesSection { resources, icc_profile })
     }
 
     /// +----------+--------------------------------------------------------------------------------------------------------------------+

--- a/src/sections/layer_and_mask_information_section/layer.rs
+++ b/src/sections/layer_and_mask_information_section/layer.rs
@@ -436,16 +436,17 @@ impl IntoRgba for PsdLayer {
         let top_in_layer = idx / self.width() as usize;
         let top_in_psd = self.layer_properties.layer_top + top_in_layer as i32;
 
-        let idx = top_in_psd
-            .checked_mul(self.layer_properties.psd_width as i32)
-            .unwrap()
-            + left_in_psd;
-
-        if idx < 0 {
-            None
-        } else {
-            Some(idx as usize)
+        if left_in_psd < 0 || left_in_psd >= self.layer_properties.psd_width as i32 {
+            return None;
         }
+        if top_in_psd < 0 || top_in_psd >= self.layer_properties.psd_height as i32 {
+            return None;
+        }
+
+        let idx = top_in_psd as usize * self.layer_properties.psd_width as usize
+            + left_in_psd as usize;
+
+        Some(idx)
     }
 
     fn red(&self) -> &ChannelBytes {

--- a/src/sections/layer_and_mask_information_section/mod.rs
+++ b/src/sections/layer_and_mask_information_section/mod.rs
@@ -337,15 +337,15 @@ fn read_layer_record(cursor: &mut PsdCursor) -> Result<LayerRecord, PsdLayerErro
 
     let left = cursor.read_i32();
 
-    // Subtract one in order to zero index. If a layer is fully transparent it's bottom will
-    // already be 0 so we don't subtract
+    // Subtract one in order to zero index. If a layer is fully transparent
+    // (or has zero area), top == bottom and/or left == right, so we must
+    // not subtract in those cases to avoid an off-by-one.
     let bottom = cursor.read_i32();
-    let bottom = if bottom == 0 { 0 } else { bottom - 1 };
+    let bottom = if bottom <= top { bottom } else { bottom - 1 };
 
-    // Subtract one in order to zero index. If a layer is fully transparent it's right will
-    // already be zero so we don't subtract.
+    // Same logic for right/left.
     let right = cursor.read_i32();
-    let right = if right == 0 { 0 } else { right - 1 };
+    let right = if right <= left { right } else { right - 1 };
 
     // Get the number of channels in the layer
     let channel_count = cursor.read_u16();

--- a/tests/image_resources_section.rs
+++ b/tests/image_resources_section.rs
@@ -83,3 +83,32 @@ fn image_odd_length_pascal_string() {
 
     assert!(psd.layers().is_empty());
 }
+
+/// Verify that ICC profile extraction works for PSD files with an embedded profile.
+///
+/// cargo test --test image_resources_section icc_profile_extracted -- --exact
+#[test]
+fn icc_profile_extracted() {
+    let psd = include_bytes!("./fixtures/green-1x1.psd");
+    let psd = Psd::from_bytes(psd).unwrap();
+
+    let icc = psd.icc_profile().expect("expected ICC profile");
+    // ICC profiles start with a 4-byte size field, then 4 bytes of padding/reserved,
+    // then a 4-byte profile/device class signature. Minimum valid size is 128 bytes (header).
+    assert!(icc.len() >= 128, "ICC profile too small: {} bytes", icc.len());
+    // The first 4 bytes are the profile size as a big-endian u32
+    let profile_size = u32::from_be_bytes([icc[0], icc[1], icc[2], icc[3]]) as usize;
+    assert_eq!(profile_size, icc.len(), "ICC profile size field mismatch");
+}
+
+/// Verify that PSD files without an ICC profile return None.
+///
+/// cargo test --test image_resources_section icc_profile_absent -- --exact
+#[test]
+fn icc_profile_absent() {
+    // layer-larger.psd has no ICC profile based on manual inspection
+    let psd = include_bytes!("./fixtures/layer-larger.psd");
+    let psd = Psd::from_bytes(psd).unwrap();
+
+    assert!(psd.icc_profile().is_none(), "expected no ICC profile");
+}


### PR DESCRIPTION
This PR adds ICC profile extraction support and fixes some issues causing a crash with 16 bit images due to some OOB issues. I have reviewed the fixes but @claude should get credit for finding the issues and fixing them as well as adding the ICC support.